### PR TITLE
Add imprecise date format support on parse Facebook auth data.

### DIFF
--- a/library/src/main/java/com/parse/FacebookController.java
+++ b/library/src/main/java/com/parse/FacebookController.java
@@ -42,8 +42,11 @@ import bolts.Task;
    */
   private static final DateFormat PRECISE_DATE_FORMAT =
       new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);
+  private static final DateFormat IMPRECISE_DATE_FORMAT =
+      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
   static {
     PRECISE_DATE_FORMAT.setTimeZone(new SimpleTimeZone(0, "GMT"));
+    IMPRECISE_DATE_FORMAT.setTimeZone(new SimpleTimeZone(0, "GMT"));
   }
 
   // Used as default activityCode. From FacebookSdk.java.
@@ -172,7 +175,7 @@ import bolts.Task;
 
     String token = authData.get(KEY_ACCESS_TOKEN);
     String userId = authData.get(KEY_USER_ID);
-    Date lastRefreshDate = PRECISE_DATE_FORMAT.parse(authData.get(KEY_REFRESH_DATE));
+    Date lastRefreshDate = parseDateString(authData.get(KEY_REFRESH_DATE));
 
     AccessToken currentAccessToken = facebookSdkDelegate.getCurrentAccessToken();
     if (currentAccessToken != null) {
@@ -212,7 +215,7 @@ import bolts.Task;
         permissions,
         null,
         null,
-        PRECISE_DATE_FORMAT.parse(authData.get(KEY_EXPIRATION_DATE)),
+        parseDateString(authData.get(KEY_EXPIRATION_DATE)),
         null);
     facebookSdkDelegate.setCurrentAccessToken(accessToken);
   }
@@ -224,6 +227,25 @@ import bolts.Task;
     void setCurrentAccessToken(AccessToken token);
     CallbackManager createCallbackManager();
     LoginManager getLoginManager();
+  }
+
+  /**
+   * Convert String representation of a date into Date object.
+   *
+   * Following date formats are supported:
+   * yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
+   * yyyy-MM-dd'T'HH:mm:ss'Z'
+   *
+   * @param source A <code>String</code> whose beginning should be parsed.
+   * @return A <code>Date</code> parsed from the string.
+   * @exception java.text.ParseException if the beginning of the specified string cannot be parsed.
+   */
+  private Date parseDateString(String source) throws java.text.ParseException {
+    try {
+        return PRECISE_DATE_FORMAT.parse(source);
+    } catch (java.text.ParseException e) {
+        return IMPRECISE_DATE_FORMAT.parse(source);
+    }
   }
 
   private static class FacebookSdkDelegateImpl implements FacebookSdkDelegate {

--- a/library/src/test/java/com/parse/FacebookControllerTest.java
+++ b/library/src/test/java/com/parse/FacebookControllerTest.java
@@ -210,6 +210,31 @@ public class FacebookControllerTest {
     verify(facebookSdk, never()).setCurrentAccessToken(any(AccessToken.class));
   }
 
+  @Test
+  public void testSetAuthDataWithImpriciseDateFormat() throws ParseException {
+    Locale.setDefault(new Locale("ar")); // Mimic the device's locale
+    TimeZone.setDefault(TimeZone.getTimeZone("PST"));
+
+    FacebookController.FacebookSdkDelegate facebookSdk =
+            mock(FacebookController.FacebookSdkDelegate.class);
+    when(facebookSdk.getApplicationId()).thenReturn("test_application_id");
+    FacebookController controller = new FacebookController(facebookSdk);
+
+    Map<String, String> authData = new HashMap<>();
+    authData.put("id", "test_id");
+    authData.put("access_token", "test_token");
+    authData.put("expiration_date", "2015-07-03T07:00:00Z");
+    authData.put("last_refresh_date", "2015-07-03T07:00:00Z");
+    controller.setAuthData(authData);
+    ArgumentCaptor<AccessToken> accessTokenCapture = ArgumentCaptor.forClass(AccessToken.class);
+    verify(facebookSdk).setCurrentAccessToken(accessTokenCapture.capture());
+    AccessToken accessToken = accessTokenCapture.getValue();
+    assertEquals("test_id", accessToken.getUserId());
+    assertEquals("test_token", accessToken.getToken());
+    assertEquals(new GregorianCalendar(2015, 6, 3).getTime(), accessToken.getExpires());
+    assertEquals("test_application_id", accessToken.getApplicationId());
+  }
+
   //endregion
 
   //region testAuthenticateAsync


### PR DESCRIPTION
Fix: ParseFacebookUtils.initialize is not completed when Facebook auth data has imprecise format date string.